### PR TITLE
Check lock state before Perseus session begins

### DIFF
--- a/Perseus.xm
+++ b/Perseus.xm
@@ -66,8 +66,9 @@ static NSString *harpe;
 %hook SBLockScreenManager
 -(BOOL)_attemptUnlockWithPasscode:(NSString *)passcode mesa:(BOOL)mesa finishUIUnlock:(BOOL)unlockUI completion:(/*^block*/id)completionHandler{
     BOOL success = %orig;
+    int lockState = [[%c(SBLockStateAggregator) sharedInstance] lockState];
     
-    if (enabled && success && !mesa && passcode && !perseus){
+    if (enabled && success && !mesa && passcode && !perseus && lockState == 0){
         sendGeneralPerseusQueryWithReply(fastUnlock, ^(xpc_object_t reply){
             BOOL onWrist = xpc_dictionary_get_int64(reply, "pairedWatchWristState") == 3;
             if (onWrist){

--- a/PrivateHeaders.h
+++ b/PrivateHeaders.h
@@ -42,6 +42,13 @@
 +(BOOL)isVisible;
 @end
 
+
+@interface SBLockStateAggregator : NSObject 
++(id)sharedInstance;
+-(int)lockState;
+@end
+
+
 //Sharing
 @interface SFBLEDevice : NSObject
 @property (assign,nonatomic) BOOL paired;


### PR DESCRIPTION
Perseus session begins only when device is unlocked.
Tested on iOS 14.1
FIX #5 